### PR TITLE
Dockerfile: Remove sh stub from balena base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -31,6 +31,9 @@ FROM balenalib/${BALENA_ARCH}-alpine:3.12-run
 
 WORKDIR /usr/app
 
+# remove the sh stub that prints image details
+RUN mv /bin/sh.real /bin/sh
+
 ENV UDEV 1
 ENV DBUS_SYSTEM_BUS_ADDRESS unix:path=/host/run/dbus/system_bus_socket
 


### PR DESCRIPTION
This stub causes noise when running automated tests over SSH.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>