### PR TITLE
lib: Add RPI3 Neuron CDS to leviathan supported devices

### DIFF
--- a/lib/workers/testbot.ts
+++ b/lib/workers/testbot.ts
@@ -15,6 +15,7 @@ import {
 	Rpi243390,
 	RevPiConnect,
 	RtRpi300,
+	RPI3Neuron,
 } from '@balena/testbot';
 import { EventEmitter } from 'events';
 import { createWriteStream } from 'fs';
@@ -67,6 +68,9 @@ const resolveDeviceInteractor = (hat: TestBotHat): DeviceInteractor => {
 	}
 	if (process.env.TESTBOT_DUT_TYPE === 'rt-rpi-300') {
 		return new RtRpi300(hat);
+	}
+	if (process.env.TESTBOT_DUT_TYPE === 'raspberrypi3-unipi-neuron') {
+		return new RPI3Neuron(hat);
 	}
 	return new RaspberryPi(hat);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -911,9 +911,9 @@
       }
     },
     "@balena/testbot": {
-       "version": "1.9.17",
-       "resolved": "https://registry.npmjs.org/@balena/testbot/-/testbot-1.9.17.tgz",
-       "integrity": "sha512-PiqycF0JXrI3mOeSUwsUWrp6vnyTnvyh60B3cVk6ETXWioPaxdk5oCDh4v/iJFzNLejebivh/b2qtmWzL0T/zw==",
+      "version": "1.9.18",
+      "resolved": "https://registry.npmjs.org/@balena/testbot/-/testbot-1.9.18.tgz",
+      "integrity": "sha512-mKbCaFmMYJH/+27572jTpMA2nYZhm78sU5QX8I2FEdvwv3SzH6JAWjvU5SC/2hA+L5YAN32+ci3lBWHhYR9TEA==",
       "requires": {
         "@types/node": "^10.12.18",
         "bin-build": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "test"
   },
   "dependencies": {
-    "@balena/testbot": "^1.9.17",
+    "@balena/testbot": "^1.9.18",
     "@types/bluebird": "^3.5.25",
     "@types/config": "0.0.34",
     "balena-sdk": "^16.12.1",


### PR DESCRIPTION
This is a CDS device, similar to the RT RPI 300
that has been recently added in the previous merged
commit.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Added as requested in internal thread https://www.flowdock.com/app/rulemotion/r-resinos/threads/_kUatH1oNk-uYMhQSwmzHphpnKq