### PR TITLE
Revert software raid support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -31,6 +31,7 @@ FROM balenalib/${BALENA_ARCH}-alpine:3.12-run
 
 WORKDIR /usr/app
 
+ENV UDEV 1
 ENV DBUS_SYSTEM_BUS_ADDRESS unix:path=/host/run/dbus/system_bus_socket
 
 # ovmf is only packaged for x86_64 and aarch64 so ignore failures on arm
@@ -44,8 +45,7 @@ RUN apk add --no-cache \
   libusb-dev dbus-dev eudev-dev \
   gstreamer-tools gst-plugins-base gst-plugins-bad gst-plugins-good \
   bridge bridge-utils iproute2 dnsmasq iptables \
-  qemu-img qemu-system-x86_64 qemu-system-aarch64 \
-  mdadm util-linux
+  qemu-img qemu-system-x86_64 qemu-system-aarch64
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache uhubctl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing || true

--- a/docker-compose.qemu.yml
+++ b/docker-compose.qemu.yml
@@ -1,0 +1,36 @@
+version: "2"
+
+services:
+  worker:
+    build:
+      context: ./worker
+      dockerfile: Dockerfile.template
+      args:
+        - BALENA_ARCH=${BALENA_ARCH:-amd64}
+    device_cgroup_rules:
+      # allow dynamic creation and access of qemu required misc chardev nodes
+      # this includes /dev/kvm, and /dev/net/tun
+      - "c 10:* rmw"
+    cap_add:
+      - NET_ADMIN # allow network setup
+    volumes:
+      - "core-storage:/data"
+      - "reports-storage:/reports"
+    environment:
+      - UDEV=0
+      - WORKER_TYPE=qemu
+      - SCREEN_CAPTURE=true
+      - WORKER_PORT # default 80 and must match client config.js workers
+      - QEMU_ARCH=${QEMU_ARCH:-x86_64}
+      - QEMU_CPUS=${QEMU_CPUS}
+      - QEMU_MEMORY=${QEMU_MEMORY}
+      - QEMU_DEBUG=${QEMU_DEBUG}
+    restart: 'no'
+
+  core:
+    depends_on:
+      - worker
+
+volumes:
+  core-storage:
+  reports-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
-    environment:
-      - UDEV=1
     labels:
       io.balena.features.dbus: '1'
       io.balena.features.balena-socket: '1'

--- a/entry.sh
+++ b/entry.sh
@@ -6,11 +6,10 @@ if [ "${WORKER_TYPE}" != "qemu" ]; then
 	exec node ./build/bin
 fi
 
-misc_major=10
 tun_minor=$(grep tun /proc/misc | cut -d ' ' -f1)
 if [ -n "${tun_minor}" ]; then
 	mkdir -p /dev/net
-	if ! mknod -m 666 /dev/net/tun c "${misc_major}" "${tun_minor}"; then
+	if ! mknod -m 666 /dev/net/tun c 10 "${tun_minor}"; then
 		echo "Unable to create TUN device node"
 		exit 1
 	fi
@@ -22,29 +21,11 @@ fi
 
 kvm_minor=$(grep kvm /proc/misc | cut -d ' ' -f1)
 if [ -n "${kvm_minor}" ]; then
-	if ! mknod -m 666 /dev/kvm c "${misc_major}" "${kvm_minor}"; then
+	if ! mknod -m 666 /dev/kvm c 10 "${kvm_minor}"; then
 		echo "Unable to create KVM device node, software emulation is still available"
 	fi
 else
 	echo "KVM is unavailable, falling back on software emulation"
 fi
-
-loop_major=7
-loopctrl_minor=$(grep loop-control /proc/misc | cut -d ' ' -f1)
-if [ -n "${loopctrl_minor}" ]; then
-	if ! mknod -m 660 /dev/loop-control c "${misc_major}" "${loopctrl_minor}"; then
-		echo "Unable to create loop-control device node"
-		exit 1
-	fi
-
-	for i in $(seq 0 128); do
-		mknod -m 660 "/dev/loop${i}" b "${loop_major}" "${i}"
-	done
-fi
-
-metadata_major=9
-for i in $(seq 0 127); do
-	mknod -m 660 "/dev/md${i}" b "${metadata_major}" "${i}"
-done
 
 node ./build/bin

--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -20,8 +20,8 @@ Bluebird.config({
 const dutSerialPath = '/reports/dut-serial.txt';
 
 class QemuWorker extends EventEmitter implements Leviathan.Worker {
-	private id: string;
 	private image: string;
+	private activeFlash?: Bluebird<void>;
 	private signalHandler: (signal: NodeJS.Signals) => Promise<void>;
 	private qemuProc: ChildProcess | null = null;
 	private dnsmasqProc: ChildProcess | null = null;
@@ -37,8 +37,6 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 
 	constructor(options: Leviathan.RuntimeConfiguration) {
 		super();
-
-		this.id = `${Math.random().toString(36).substring(2, 10)}`;
 
 		if (options != null) {
 			this.image =
@@ -157,53 +155,39 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	}
 
 	public async flash(stream: Stream.Readable): Promise<void> {
-		await this.powerOff();
-
-		await execProm(`fallocate -l 8G ${this.image}`);
-		const loopbackDevice = (
-			await execProm(`losetup -fP --show ${this.image}`)
-		).stdout.trim();
-		const arrayDevice = `/dev/md/${this.id}`;
-		try {
-			await execProm([
-				'yes', '|',
-					'mdadm',
-						'--create',
-						'--verbose',
-						'--level=1',
-						'--raid-devices=1',
-						'--metadata=0.90',
-						'--force',
-						arrayDevice,
-						loopbackDevice,
-				].join(' ')
-			);
+		this.activeFlash = new Bluebird(async (resolve, reject) => {
+			await this.powerOff();
 
 			const source = new sdk.sourceDestination.SingleUseStreamSource(stream);
 
 			const destination = new sdk.sourceDestination.File({
-				path: arrayDevice,
+				path: this.image,
 				write: true,
 			});
 
-			await new Bluebird((resolve, reject) => {
-				sdk.multiWrite.pipeSourceToDestinations({
-					source: source,
-					destinations: [destination],
-					onFail:
-					(_destination, error) => {
-						reject(error);
-					},
-					onProgress: (progress: sdk.multiWrite.MultiDestinationProgress) => {
-						this.emit('progress', progress);
-					},
-					verify: true,
-				}).then(resolve);
+			await sdk.multiWrite.pipeSourceToDestinations({
+				source: source,
+				destinations: [destination],
+				onFail:
+				(_destination, error) => {
+					reject(error);
+				},
+				onProgress: (progress: sdk.multiWrite.MultiDestinationProgress) => {
+					this.emit('progress', progress);
+				},
+				verify: true,
 			});
-		} finally {
-			await execProm(`mdadm --stop ${arrayDevice}`);
-			await execProm(`losetup -d ${loopbackDevice}`);
-		}
+
+			// Image files must be resized using qemu-img to create space for the data partition
+			console.debug(`Resizing qemu image...`);
+			await execProm(`qemu-img resize -f raw ${this.image} 8G`);
+			console.debug(`qemu image resized!`);
+
+			resolve();
+		});
+
+		await this.activeFlash;
+		this.activeFlash = undefined;
 	}
 
 	private async findUEFIFirmware(
@@ -527,7 +511,9 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		 */
 		if (this.qemuOptions.network.autoconfigure) {
 			if (this.qemuOptions.network.bridgeName === null) {
-				this.bridgeName = `br${this.id}`;
+				// generate random bridge name
+				const id = `${Math.random().toString(36).substring(2, 10)}`;
+				this.bridgeName = `br${id}`;
 			} else {
 				this.bridgeName = this.qemuOptions.network.bridgeName;
 			}


### PR DESCRIPTION
Reverts balena-os/leviathan-worker#21

The original PR is not compatible with existing balenaOS releases and is blocking testing. This feature should be re-implemented with a toggle that is disabled by default.