### PR TITLE
qemu: add internal/external storage

### DIFF
--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -19,7 +19,8 @@ const dutSerialPath = '/reports/dut-serial.txt';
 
 class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	private id: string;
-	private image: string;
+	private internalDisk: string;
+	private externalDisk: string;
 	private signalHandler: (signal: NodeJS.Signals) => Promise<void>;
 	private qemuProc: ChildProcess | null = null;
 	private dnsmasqProc: ChildProcess | null = null;
@@ -39,10 +40,11 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		this.id = `${Math.random().toString(36).substring(2, 10)}`;
 
 		if (options != null) {
-			this.image =
+			this.externalDisk =
 				options.worker != null && options.worker.disk != null
 					? options.worker.disk
-					: '/data/os.img';
+					: '/data/externalDisk.img';
+			this.internalDisk = '/data/internalDisk.img';
 
 			if (options.screenCapture) {
 				this.screenCapturer = new ScreenCapture(
@@ -157,9 +159,9 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 	public async flash(stream: Stream.Readable): Promise<void> {
 		await this.powerOff();
 
-		await execProm(`fallocate -l 8G ${this.image}`);
-		const loopbackDevice = this.qemuOptions.forceRaid
-			? (await execProm(`losetup -fP --show ${this.image}`)).stdout.trim()
+		await execProm(`truncate -s 8G ${this.internalDisk} ${this.externalDisk}`);
+		const loopDevice = this.qemuOptions.forceRaid
+			? (await execProm(`losetup -fP --show ${this.internalDisk}`)).stdout.trim()
 			: null;
 		const arrayDevice = this.qemuOptions.forceRaid
 			? `/dev/md/${this.id}`
@@ -177,7 +179,11 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 							'--metadata=0.90',
 							'--force',
 							arrayDevice,
-							loopbackDevice,
+							loopDevice,
+						'&&',
+							'mdadm',
+								'--stop',
+								arrayDevice,
 					].join(' ')
 				);
 			}
@@ -185,7 +191,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			const source = new sdk.sourceDestination.SingleUseStreamSource(stream);
 
 			const destination = new sdk.sourceDestination.File({
-				path: this.qemuOptions.forceRaid ? arrayDevice! : this.image,
+				path: this.externalDisk,
 				write: true,
 			});
 
@@ -206,7 +212,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		} finally {
 			if (this.qemuOptions.forceRaid) {
 				await execProm(`mdadm --stop ${arrayDevice}`);
-				await execProm(`losetup -d ${loopbackDevice}`);
+				await execProm(`losetup -d ${loopDevice}`);
 			}
 		}
 	}
@@ -303,10 +309,18 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 			this.qemuOptions.memory,
 			'-smp',
 			this.qemuOptions.cpus,
-			'-drive',
-			`format=raw,file=${this.image},if=virtio`,
 			'-serial',
 			`file:${dutSerialPath}`,
+		];
+
+		const internalStorageArgs = [
+			'-drive', `format=raw,file=${this.internalDisk},media=disk`,
+		];
+
+		const externalStorageArgs = [
+			'-drive', `format=raw,file=${this.externalDisk},if=none,id=ext0`,
+			'-device', 'qemu-xhci',
+			'-device', 'usb-storage,drive=ext0,bootindex=1',
 		];
 
 		// Basic mapping of node process.arch to matching qemu target architecture
@@ -361,6 +375,8 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		};
 		const qmpArgs = ['-qmp', `tcp:localhost:${qmpPort},server,nowait`];
 		let args = baseArgs
+			.concat(internalStorageArgs)
+			.concat(externalStorageArgs)
 			.concat(archArgs[deviceArch])
 			.concat(networkArgs)
 			.concat(firmwareArgs[deviceArch])


### PR DESCRIPTION
Allow for booting works from external storage, with blank internal storage available for flashing. This will enable flasher images to be tested without unwrapping.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>