### PR TITLE
Add make config to e2e suite to dump merged compose files

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -120,7 +120,9 @@ jobs:
       #   run: #TODO
       
       - name: Run test suite
-        run: make test
+        run: |
+          make config
+          make test
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
This can be useful to visualize in the logs what env vars were set, what worker image was pulled, etc.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>