### PR TITLE
e2e: substitute the worker release in the compose file

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -110,7 +110,9 @@ jobs:
           echo "WORKER_RELEASE=${commit}" >> $GITHUB_ENV
 
       - name: Copy suite config
-        run: cp -a ${{ env.SUITES }}/config.js ${{ env.WORKSPACE }}/config.js
+        run: |
+          cp -a ${{ env.SUITES }}/config.js ${{ env.WORKSPACE }}/config.js
+          sed -r 's|(bh\.cr/balena/leviathan-worker(-[^/]+)?)/.+|\1/${{ env.WORKER_RELEASE }}|' -i docker-compose.qemu.yml
 
       - name: Build leviathan images
         run: make build


### PR DESCRIPTION
Use regex to set the worker release commit in the compose file before running e2e tests.

This allows us to deprecate the WORKER_RELEASE env var.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>