### PR TITLE
Qemu flasher secureboot

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,6 +17,7 @@ module.exports = {
 				memory: process.env.QEMU_MEMORY || '512M',
 				debug: process.env.QEMU_DEBUG || false,
 				forceRaid: process.env.QEMU_FORCE_RAID || false,
+				secureBoot: process.env.QEMU_SECUREBOOT || false,
 				network: {
 					autoconfigure: true,
 					bridgeName: process.env.QEMU_BRIDGE_NAME || null,

--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -429,7 +429,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 				'-drive',
 				`if=pflash,format=raw,unit=1,file=${
 					this.qemuOptions.firmware!.vars
-				},readonly=on`,
+				}`,
 			],
 			aarch64: ['-bios', this.qemuOptions.firmware!.code],
 		};

--- a/typings/worker.d.ts
+++ b/typings/worker.d.ts
@@ -27,6 +27,7 @@ declare global {
 				vars: string
 			},
 			forceRaid: boolean;
+			secureBoot: boolean;
 			network: {
 				autoconfigure: boolean;
 				bridgeName: string;


### PR DESCRIPTION
This adds onto the previous `qemu-flasher` PR (now merged), which allowed for testing flasher images without unwrapping them.

This PR adds on support for testing secure boot enabled flasher images.