### PR TITLE
patch: npm CI once to save time

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -22,11 +22,6 @@ COPY bin ./bin
 # build typescript
 RUN npm run build
 
-FROM build-base as node-prod
-
-# install locked production dependencies
-RUN npm ci --production
-
 FROM balenalib/${BALENA_ARCH}-alpine:3.12-run
 
 WORKDIR /usr/app
@@ -59,8 +54,8 @@ RUN mkdir -p /etc/qemu \
   && echo "allow all" > /etc/qemu/bridge.conf \
   && chmod 0640 /etc/qemu/bridge.conf
 
-COPY --from=node-prod /usr/app/package.json ./
-COPY --from=node-prod /usr/app/node_modules ./node_modules
+COPY --from=node-dev /usr/app/package.json ./
+COPY --from=node-dev /usr/app/node_modules ./node_modules
 COPY --from=node-dev /usr/app/build ./build
 
 COPY entry.sh entry.sh


### PR DESCRIPTION
@klutchell Do you know why we have the second alpine base image without node in it and then we go ahead to install node in it for some reason. It was 8 months ago and I can see the size advantage one would get of going that way. But, just asking once. 


Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipul@balena.io>
