### PR TITLE
Dockerfile: install aavmf when available

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -46,6 +46,8 @@ RUN apk add --no-cache \
   qemu-img qemu-system-x86_64 qemu-system-aarch64 \
   python3 py3-pip py3-setuptools \
   mdadm util-linux
+
+RUN apk add --no-cache aavmf || true
   
 # hadolint ignore=DL3018
 RUN apk add --no-cache uhubctl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community || true


### PR DESCRIPTION
After upgrading the alpine base image, the AAVMF vars file is no longer installed by the qemu-system-aarch64 package. Install AAVMF to get a compatible code and vars firmware.

Change-type: patch