### PR TITLE
stop crash when using networkWireless: true

### DIFF
--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -14,6 +14,7 @@ import * as net from 'net';
 const qmp = require("@balena/node-qmp");
 const execProm = promisify(exec);
 import * as fp from 'find-free-port';
+import { Supported } from '../helpers/nm';
 
 const imagefs = require('balena-image-fs');
 const util = require('util');
@@ -698,9 +699,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		});
 	}
 
-	public async network(configuration: {
-		wired?: { nat: boolean };
-	}): Promise<void> {
+	public async network(configuration: Supported['configuration']): Promise<void> {
 		/* Network configuration, including creating a bridge, setting iptables
 		 * rules, and running a DHCP server, requires privileges. This can all be
 		 * done easily in a container, but would otherwise necessitate running the


### PR DESCRIPTION
quick fix to stop the qemu working crashing when accidently giving networkWireless: true - this attribute isn't used anyway for this worker, and it simplifies the test suit to just ignore it

Change-type: patch