### PR TITLE
qemu: remove bootindex from external disk

### DIFF
--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -445,7 +445,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		const externalStorageArgs = [
 			'-drive', `format=raw,file=${this.externalDisk},if=none,id=ext0`,
 			'-device', 'qemu-xhci',
-			'-device', 'usb-storage,drive=ext0,bootindex=1',
+			'-device', 'usb-storage,drive=ext0',
 		];
 
 		const tpmArgs = [

--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -275,12 +275,6 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 				await execProm(`mdadm --stop ${arrayDevice}`);
 				await execProm(`losetup -d ${loopDevice}`);
 			}
-			if (this.flasherImage && this.qemuOptions.internalStorage && this.qemuOptions.externalStorage) {
-				// Remove external disk after programming internal one as EFI boot
-				// is not changed for QEMU
-				console.log(`Removing external disk`)
-				this.qemuOptions.externalStorage = false;
-			}
 		}
 	}
 


### PR DESCRIPTION
This property appears to alter the behavior of the automatic boot device selection of OVMF in such a way that the internal disk is no longer booted as expected automatically after flashing with the external disk still attached. Remove it.

Change-type: patch