### PR TITLE
use balena api env var instead of hard-coding

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,7 +22,7 @@ import * as lockfile from 'proper-lockfile';
 import * as serialTerminal from '@balena/node-serial-terminal';
 
 const balena = getSdk({
-	apiUrl: 'https://api.balena-cloud.com/',
+	apiUrl: process.env.BALENA_API_URL,
 });
 
 const workersDict: Dictionary<typeof TestBotWorker | typeof QemuWorker | typeof AutokitWorker> = {


### PR DESCRIPTION
replace the hard coded balena api url with the device env variable instead. Needed to enable using workers on different environments (staging/balena machine)

Change-type: patch