### PR TITLE
change defaults for autokit worker

### DIFF
--- a/lib/workers/autokit.ts
+++ b/lib/workers/autokit.ts
@@ -21,7 +21,7 @@ class AutokitWorker extends EventEmitter implements Leviathan.Worker {
             video: process.env.VIDEO || 'linuxVideo',
 			serial: process.env.SERIAL || 'dummySerial',
             usbBootPort: process.env.USB_BOOT_PORT || '4',
-			digitalRelay: process.env.DIGITAL_RELAY || 'usbRelay'
+			digitalRelay: process.env.DIGITAL_RELAY || 'dummyPower'
         }
 
 		this.autoKit = new Autokit(autokitConfig);


### PR DESCRIPTION
avoid container crashlooping when no secondary, boot switch relay connected, which is most cases

Change-type: patch