### PR TITLE
workers/qemu: start qemu without default interfaces

### DIFF
--- a/lib/workers/qemu.ts
+++ b/lib/workers/qemu.ts
@@ -440,6 +440,7 @@ class QemuWorker extends EventEmitter implements Leviathan.Worker {
 		];
 
 		const externalStorageArgs = [
+			'-nodefaults',
 			'-drive', `format=raw,file=${this.externalDisk},if=none,id=ext0`,
 			'-device', 'qemu-xhci',
 			'-device', 'usb-storage,drive=ext0',


### PR DESCRIPTION
Remove default interfaces like CDROMs, floppy disk and other to avoid boot order problems and guarantee the system boots with only one block disk so the migration is always performed.

Fixes balena-os/balena-generic/#265

Change-type: patch