### PR TITLE
patch: Create new action for balenamachine push

### DIFF
--- a/.github/workflows/balenamachine-push.yml
+++ b/.github/workflows/balenamachine-push.yml
@@ -1,0 +1,50 @@
+name: 'Push to balenaMachine on successful release'
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+  # allow external contributions to use secrets within trusted code
+  pull_request_target:
+    types: [closed]
+    branches: [master]
+
+jobs:
+  balenamachine-push:
+    needs: [flowzone]
+
+    # prevent duplicate workflows and only allow one `pull_request` or `pull_request_target` for
+    # internal or external contributions respectively
+    if: |
+      (github.event.pull_request.head.repo.full_name == github.repository && github.event_name == 'pull_request') ||
+      (github.event.pull_request.head.repo.full_name != github.repository && github.event_name == 'pull_request_target') &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-22.04
+    
+    steps:
+      - uses: actions/checkout@v3
+      - name: Describe git state
+        id: git_describe
+        shell: bash
+        run: |
+          describe="$(git describe HEAD --tags --always)"
+          semver="$(npx -q -y -- semver -c -l "${describe}")"
+          echo "semver=${semver}" >> $GITHUB_OUTPUT
+
+      - name: Update balenaMachine docker-compose.yml
+        id: update-compose
+        shell: bash
+        run: |
+          sed -r 's|build: .|image: bh\.cr/balena/leviathan-worker-${BALENA_ARCH:-amd64}/${{ steps.git_describe.outputs.semver }} |' -i docker-compose.yml
+          cat docker-compose.yml
+          sleep 30
+
+      - name: Deploy to balenaMachine
+        uses: balena-io/deploy-to-balena-action@master
+        with:
+          balena_token: ${{ secrets.BALENAMACHINE_API_KEY }}
+          fleet: balena/testbot-rig
+          environment: 'bm.balena-dev.com'
+          debug: true 
+          source: .
+    


### PR DESCRIPTION
Due to how deploy-to-balena operates using a finalize action only lets you finalize releases not push new ones AFAIK. 
So creating a new action to push only when PRs are closed. 

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
