### PR TITLE
enable jetson-flash device types

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -34,6 +34,10 @@ RUN git clone https://git.tizen.org/cgit/tools/testlab/sd-mux &&\
 RUN git clone https://github.com/balena-io-hardware/crelay.git && \
   cd crelay/src && make [DRV_CONRAD=n] [DRV_SAINSMART=n] [DRV_HIDAPI=n] && make install
 
+# install jetson-flash tooling
+RUN git clone https://github.com/balena-os/jetson-flash.git && \
+  cd jetson-flash && git checkout v0.5.56
+
 FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811
 
 WORKDIR /usr/app
@@ -52,7 +56,10 @@ RUN apk add --no-cache \
   bridge bridge-utils iproute2 dnsmasq iptables \
   qemu-img qemu-system-x86_64 qemu-system-aarch64 qemu-system-arm \
   python3 py3-pip py3-setuptools \
-  mdadm util-linux libftdi1-dev popt-dev hidapi-dev
+  mdadm util-linux libftdi1-dev popt-dev hidapi-dev ca-certificates docker
+
+# fail if binaries are missing or won't run
+RUN dockerd --version && docker --version
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache uhubctl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community || true
@@ -75,6 +82,9 @@ COPY  --from=node-prod /usr/app/sd-mux/build/src/sd-mux-ctrl /usr/local/sbin/sd-
 # Copy crelay binary
 COPY --from=node-prod /usr/app/crelay/src/crelay /usr/local/bin/crelay
 RUN chmod +x /usr/local/bin/crelay
+
+# Copy jetson-flash
+COPY --from=node-prod /usr/app/jetson-flash/ /usr/app/jetson-flash
 
 COPY entry.sh entry.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.1'
 volumes:
   core-storage:
   reports-storage:
+  docker: 
 services:
   worker:
     privileged: true
@@ -12,10 +13,13 @@ services:
     volumes:
       - 'core-storage:/data'
       - 'reports-storage:/reports'
+      - docker:/var/lib/docker
+    tmpfs:
+      - /tmp
+      - /var/log
     environment:
       - UDEV=1
     labels:
       io.balena.features.dbus: '1'
-      io.balena.features.balena-socket: '1'
       io.balena.features.balena-api: '1'
       io.balena.features.kernel-modules: '1'

--- a/entry.sh
+++ b/entry.sh
@@ -3,7 +3,14 @@ modprobe sg
 
 eval $(ssh-agent)
 
+# Only start docker in docker if not using the qemu worker
 if [ "${WORKER_TYPE}" != "qemu" ]; then
+	rm -rf /var/run/docker 2>/dev/null || true
+	rm -f /var/run/docker.sock 2>/dev/null || true
+	rm -f /var/run/docker.pid 2>/dev/null || true
+
+	dockerd &
+
 	exec node ./build/bin
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/autokit": "^1.0.14",
+        "@balena/autokit": "^1.0.15",
         "@balena/node-qmp": "^0.0.5",
         "@balena/node-serial-terminal": "^0.0.2",
         "@balena/testbot": "^1.9.27",
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@balena/autokit": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.14.tgz",
-      "integrity": "sha512-S7ooqJnZfr3ENaOACJREka63Gwa8FaGcORKicdScbuYTtcuEMjaiX3w3dk4dwetyhL5kFtLuNLOn27aPOECbVg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.15.tgz",
+      "integrity": "sha512-uDlzPnu06VDA0LSLZLzlXw7SjfVrae7Sum03Q0TjtKx6qsL0MenzhzZJPzLhqfvfqmoJ46LK93yxvw+mHF2gbw==",
       "dependencies": {
         "@balena/usbrelay": "^0.1.4",
         "@types/multer": "^1.4.7",
@@ -15461,9 +15461,9 @@
       }
     },
     "@balena/autokit": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.14.tgz",
-      "integrity": "sha512-S7ooqJnZfr3ENaOACJREka63Gwa8FaGcORKicdScbuYTtcuEMjaiX3w3dk4dwetyhL5kFtLuNLOn27aPOECbVg==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.15.tgz",
+      "integrity": "sha512-uDlzPnu06VDA0LSLZLzlXw7SjfVrae7Sum03Q0TjtKx6qsL0MenzhzZJPzLhqfvfqmoJ46LK93yxvw+mHF2gbw==",
       "requires": {
         "@balena/usbrelay": "^0.1.4",
         "@types/multer": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bin": "bin"
   },
   "dependencies": {
-    "@balena/autokit": "^1.0.14",
+    "@balena/autokit": "^1.0.15",
     "@balena/node-qmp": "^0.0.5",
     "@balena/node-serial-terminal": "^0.0.2",
     "@balena/testbot": "^1.9.27",


### PR DESCRIPTION
This required:
- adding docker in docker to the worker container - this is because jetson-flash uses a container
- adding the jetson-flash device type flashing logic to the autokit sdk - code here builds and starts the jetson flash container
- docker in docker is not started with the qemu worker - as it is not needed.