### PR TITLE
patch: Provide more memory to QEMU instances

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,7 +18,7 @@ export const config = {
 			qemu: {
 				architecture: process.env.QEMU_ARCH || 'x86_64',
 				cpus: process.env.QEMU_CPUS || '4',
-				memory: process.env.QEMU_MEMORY || '512M',
+				memory: process.env.QEMU_MEMORY || '2G',
 				debug: process.env.QEMU_DEBUG || false,
 				forceRaid: process.env.QEMU_FORCE_RAID || false,
 				secureBoot: process.env.QEMU_SECUREBOOT || false,


### PR DESCRIPTION
With 512M, QEMU was not operating properly and wasn't reachable after the first reboot of the system.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
