### PR TITLE
reduce frequency of balena push failures in PR checks

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       balena_slugs:
         balena/testbot-rig,
+        balena/testbot-personal,
         balena/leviathan-worker-amd64,
         balena/leviathan-worker-aarch64,
         balena/leviathan-worker-armv7hf
@@ -70,6 +71,9 @@ jobs:
           - DEVICE_TYPE: generic-aarch64
             WORKER_TYPE: qemu
             WORKER_APP_ID: "1941514" # balena/leviathan-worker-aarch64
+          - DEVICE_TYPE: raspberrypi3
+            WORKER_TYPE: testbot
+            WORKER_APP_ID: "1941517" # balena/leviathan-worker-armv7hf
           #  Commented because testbot devices aren't available to test worker releases
           # - DEVICE_TYPE: raspberrypi3
           #   WORKER_TYPE: testbot

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       balena_slugs:
         balena/testbot-rig,
-        balena/testbot-personal,
         balena/leviathan-worker-amd64,
         balena/leviathan-worker-aarch64,
         balena/leviathan-worker-armv7hf

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,19 +33,19 @@ FROM build-base as node-prod
 RUN npm ci --production
 
 # build sdwire sdmux tooling
-RUN git clone --depth 1 https://github.com/emaste/sd-mux.git &&\
+RUN GIT_TRACE_CURL=true git clone --depth 1 https://github.com/emaste/sd-mux.git 2>&1 >/dev/null | head -n 5 &&\
   mkdir sd-mux/build && cd sd-mux/build && cmake ../ && make
 
 # install Crelay tooling
-RUN git clone https://github.com/balena-io-hardware/crelay.git && \
+RUN GIT_TRACE_CURL=true git clone https://github.com/balena-io-hardware/crelay.git 2>&1 >/dev/null | head -n 5 && \
   cd crelay/src && make [DRV_CONRAD=n] [DRV_SAINSMART=n] [DRV_HIDAPI=n] && make install
 
 # install jetson-flash tooling
-RUN git clone https://github.com/balena-os/jetson-flash.git && \
+RUN GIT_TRACE_CURL=true git clone https://github.com/balena-os/jetson-flash.git 2>&1 >/dev/null | head -n 5 && \
   cd jetson-flash && git checkout master
 
 # install jetson-flash tooling
-RUN git clone https://github.com/balena-os/iot-gate-imx8plus-flashtools.git && \
+RUN GIT_TRACE_CURL=true git clone https://github.com/balena-os/iot-gate-imx8plus-flashtools.git 2>&1 >/dev/null | head -n 5 && \
   cd iot-gate-imx8plus-flashtools && git checkout master
 
 FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811 AS build-base
 WORKDIR /usr/app
 
 # DEbugging steps : PLEASE REMOVE
-RUN /sbin/setup-apkrepos
+RUN setup-apkrepos
 RUN curl -vvv https://dl-cdn.alpinelinux.org/alpine/v3.17/main/
 RUN cat /etc/apk/repositories
 RUN apk update 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,6 +4,10 @@ FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811 AS build-base
 
 WORKDIR /usr/app
 
+# DEbugging steps : PLEASE REMOVE
+RUN cat /etc/apk/repositories
+RUN apk update 
+
 # hadolint ignore=DL3018
 RUN apk add --no-cache libusb-dev dbus-dev python3 make build-base cmake git linux-headers eudev-dev libftdi1-dev popt-dev hidapi-dev
 COPY package*.json ./

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811 AS build-base
 WORKDIR /usr/app
 
 # DEbugging steps : PLEASE REMOVE
-RUN setup-apkrepos
+# RUN setup-apkrepos
 RUN curl -vvv https://dl-cdn.alpinelinux.org/alpine/v3.17/main/
 RUN cat /etc/apk/repositories
 RUN apk update 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,6 +5,8 @@ FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811 AS build-base
 WORKDIR /usr/app
 
 # DEbugging steps : PLEASE REMOVE
+RUN /sbin/setup-apkrepos
+RUN curl -vvv https://dl-cdn.alpinelinux.org/alpine/v3.17/main/
 RUN cat /etc/apk/repositories
 RUN apk update 
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,19 +33,19 @@ FROM build-base as node-prod
 RUN npm ci --production
 
 # build sdwire sdmux tooling
-RUN GIT_TRACE_CURL=true git clone --depth 1 https://github.com/emaste/sd-mux.git 2>&1 >/dev/null | head -n 5 &&\
+RUN ping -c 1 github.com && GIT_TRACE_CURL=true git clone --depth 1 https://github.com/emaste/sd-mux.git 2>&1 >/dev/null | head -n 10 &&\
   mkdir sd-mux/build && cd sd-mux/build && cmake ../ && make
 
 # install Crelay tooling
-RUN GIT_TRACE_CURL=true git clone https://github.com/balena-io-hardware/crelay.git 2>&1 >/dev/null | head -n 5 && \
+RUN ping -c 1 github.com && GIT_TRACE_CURL=true git clone https://github.com/balena-io-hardware/crelay.git 2>&1 >/dev/null | head -n 10 && \
   cd crelay/src && make [DRV_CONRAD=n] [DRV_SAINSMART=n] [DRV_HIDAPI=n] && make install
 
 # install jetson-flash tooling
-RUN GIT_TRACE_CURL=true git clone https://github.com/balena-os/jetson-flash.git 2>&1 >/dev/null | head -n 5 && \
+RUN ping -c 1 github.com && GIT_TRACE_CURL=true git clone https://github.com/balena-os/jetson-flash.git 2>&1 >/dev/null | head -n 10 && \
   cd jetson-flash && git checkout master
 
 # install jetson-flash tooling
-RUN GIT_TRACE_CURL=true git clone https://github.com/balena-os/iot-gate-imx8plus-flashtools.git 2>&1 >/dev/null | head -n 5 && \
+RUN ping -c 1 github.com && GIT_TRACE_CURL=true git clone https://github.com/balena-os/iot-gate-imx8plus-flashtools.git 2>&1 >/dev/null | head -n 10 && \
   cd iot-gate-imx8plus-flashtools && git checkout master
 
 FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,7 @@ FROM build-base as node-prod
 RUN npm ci --production
 
 # build sdwire sdmux tooling
-RUN git clone https://git.tizen.org/cgit/tools/testlab/sd-mux &&\
+RUN git clone https://github.com/emaste/sd-mux.git &&\
   mkdir sd-mux/build && cd sd-mux/build && cmake ../ && make
 
 # install Crelay tooling

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,7 @@ FROM build-base as node-prod
 RUN npm ci --production
 
 # build sdwire sdmux tooling
-RUN git clone https://github.com/emaste/sd-mux.git &&\
+RUN git clone --depth 1 https://github.com/emaste/sd-mux.git &&\
   mkdir sd-mux/build && cd sd-mux/build && cmake ../ && make
 
 # install Crelay tooling


### PR DESCRIPTION
- PR's in this repo almost always fail multiple times due to the various `balena push` steps failing
- the failures are due to connectivity issues during the build, most often the cloning of `sd-mux-ctrl` from tizens git repository
- I changed the dockerfile to clone from a github mirror which is more consistent, and also removed testbot-personal from the push targets as its unused, and is another chance for a failure we don't really need