### PR TITLE
remove all git clones from dockerfile

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -26,22 +26,6 @@ FROM build-base as node-prod
 # install locked production dependencies
 RUN npm ci --production
 
-# build sdwire sdmux tooling
-RUN git clone https://git.tizen.org/cgit/tools/testlab/sd-mux &&\
-  mkdir sd-mux/build && cd sd-mux/build && cmake ../ && make
-
-# install Crelay tooling
-RUN git clone https://github.com/balena-io-hardware/crelay.git && \
-  cd crelay/src && make [DRV_CONRAD=n] [DRV_SAINSMART=n] [DRV_HIDAPI=n] && make install
-
-# install jetson-flash tooling
-RUN git clone https://github.com/balena-os/jetson-flash.git && \
-  cd jetson-flash && git checkout master
-
-# install jetson-flash tooling
-RUN git clone https://github.com/balena-os/iot-gate-imx8plus-flashtools.git && \
-  cd iot-gate-imx8plus-flashtools && git checkout master
-
 FROM balenalib/${BALENA_ARCH}-alpine-node:16-run-20230811
 
 WORKDIR /usr/app
@@ -79,19 +63,6 @@ RUN mkdir -p /etc/qemu \
 COPY --from=node-prod /usr/app/package.json ./
 COPY --from=node-prod /usr/app/node_modules ./node_modules
 COPY --from=node-dev /usr/app/build ./build
-
-# Copy sdwire sdmux binary
-COPY  --from=node-prod /usr/app/sd-mux/build/src/sd-mux-ctrl /usr/local/sbin/sd-mux-ctrl
-
-# Copy crelay binary
-COPY --from=node-prod /usr/app/crelay/src/crelay /usr/local/bin/crelay
-RUN chmod +x /usr/local/bin/crelay
-
-# Copy jetson-flash
-COPY --from=node-prod /usr/app/jetson-flash/ /usr/app/jetson-flash
-
-# Copy IOT-GATE flash
-COPY --from=node-prod /usr/app/iot-gate-imx8plus-flashtools /usr/app/iot-gate-imx8plus-flashtools
 
 
 COPY entry.sh entry.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/autokit": "^1.0.19",
+        "@balena/autokit": "^1.0.21",
         "@balena/node-qmp": "^0.0.5",
         "@balena/node-serial-terminal": "^0.0.2",
         "@balena/testbot": "^1.9.27",
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@balena/autokit": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.19.tgz",
-      "integrity": "sha512-DTG1eK8XedO25jjILMPDYYSyka+fiSvTdJRubyb5A9kQ9Yv3ExDjtrpTM+YNcKU0TZD7U+QbX7NUNuC8HYoMoA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.21.tgz",
+      "integrity": "sha512-+DdtkSKrnmEa494VYcwjtiSctYfuzDm+7d/FxH7rk/lS2pxmSfm/eE72bJoG2+XnAwIcej/YTuY0BI+r9uxVBA==",
       "dependencies": {
         "@balena/usbrelay": "^0.1.4",
         "@types/multer": "^1.4.7",
@@ -15461,9 +15461,9 @@
       }
     },
     "@balena/autokit": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.19.tgz",
-      "integrity": "sha512-DTG1eK8XedO25jjILMPDYYSyka+fiSvTdJRubyb5A9kQ9Yv3ExDjtrpTM+YNcKU0TZD7U+QbX7NUNuC8HYoMoA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.21.tgz",
+      "integrity": "sha512-+DdtkSKrnmEa494VYcwjtiSctYfuzDm+7d/FxH7rk/lS2pxmSfm/eE72bJoG2+XnAwIcej/YTuY0BI+r9uxVBA==",
       "requires": {
         "@balena/usbrelay": "^0.1.4",
         "@types/multer": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bin": "bin"
   },
   "dependencies": {
-    "@balena/autokit": "^1.0.19",
+    "@balena/autokit": "^1.0.21",
     "@balena/node-qmp": "^0.0.5",
     "@balena/node-serial-terminal": "^0.0.2",
     "@balena/testbot": "^1.9.27",


### PR DESCRIPTION
Removed all git clones from the dockerfile, instead installing relevant tooling in the autokit initialisation, for several reasons:
- the git clones were often resulting in errors during the container build on balena cloud builders
- these tools are dependent on the specific hardware connected to the autokit - in most cases they won't be needed - it makes no sense to have them in this dockerfile

Change-type: patch