### PR TITLE
Add testbot-rig-partners for Leviathan-worker deploy

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -22,7 +22,6 @@ jobs:
     with:
       balena_slugs:
         balena/testbot-rig,
-        balena/testbot-personal,
         balena/leviathan-worker-amd64,
         balena/leviathan-worker-aarch64,
         balena/leviathan-worker-armv7hf

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       balena_slugs:
         balena/testbot-rig,
+        balena/testbot-rig-partners,
         balena/leviathan-worker-amd64,
         balena/leviathan-worker-aarch64,
         balena/leviathan-worker-armv7hf


### PR DESCRIPTION
- remove personal fleet as it was unused and just another place for the balena push CI action to fail
- add partners rig for external autokit users