### PR TITLE
update autokit to 1.0.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/autokit": "^1.0.34",
+        "@balena/autokit": "^1.0.37",
         "@balena/node-qmp": "^0.0.5",
         "@balena/node-serial-terminal": "^0.0.2",
         "@balena/testbot": "^1.9.28",
@@ -781,9 +781,9 @@
       }
     },
     "node_modules/@balena/autokit": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.34.tgz",
-      "integrity": "sha512-HHMCLE/+Ug65Dc+VilYWT4lhxDvRqvE2OKv64Zf8KFqzZS7wa5FbCfwk95cR6aXfGxE0ErUeUBMAQD3xLrwqxQ==",
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.0.37.tgz",
+      "integrity": "sha512-V2jfYG6eO1LdjAAO9rqtBnIb073ieP6KDT+FZ+i5bw+R6Hf5tGdDTYawq2D7QdDryuJU7ii5SC010StNFM/Zxw==",
       "dependencies": {
         "@balena/usbrelay": "^0.1.4",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bin": "bin"
   },
   "dependencies": {
-    "@balena/autokit": "^1.0.34",
+    "@balena/autokit": "^1.0.37",
     "@balena/node-qmp": "^0.0.5",
     "@balena/node-serial-terminal": "^0.0.2",
     "@balena/testbot": "^1.9.28",


### PR DESCRIPTION
includes fixes for selecting wifi AP channel, updates for the iot-gate-imx8 flashing tools and new linux gmbh revision

Change-type: patch