### PR TITLE
Extend renovate config from balena-io

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["github>balena-io/renovate-config"]
+}


### PR DESCRIPTION
The config shared by balena-os is tuned for yocto-device-type repositories and not appropriate for generic and nodeJS repos.

Change-type: patch