### PR TITLE
leviathan-worker: Bump autokit to v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@balena/autokit": "^1.2.1",
+        "@balena/autokit": "^1.2.3",
         "@balena/node-qmp": "^0.0.5",
         "@balena/node-serial-terminal": "^0.0.2",
         "@balena/testbot": "^1.9.28",
@@ -859,10 +859,9 @@
       }
     },
     "node_modules/@balena/autokit": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.2.1.tgz",
-      "integrity": "sha512-F75tIAuCjIo+OPwaHFrx3Xal0xjL/E4NTgdKJDEIt4Km1oBs0N9dxAPJVsTNJBRn2nRiH3bEpM0Sjmf41X917g==",
-      "license": "Apache-2.0",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@balena/autokit/-/autokit-1.2.3.tgz",
+      "integrity": "sha512-enJY8rdEZrjKhf07ph6QXgY84TAOhXldHjk/nzN5lUF3phZZ6xOGsc4Deuq1ml+NpLkSCark3VgUKLM4hZBv+Q==",
       "dependencies": {
         "@balena/usbrelay": "^0.1.4",
         "@serialport/parser-readline": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bin": "bin"
   },
   "dependencies": {
-    "@balena/autokit": "^1.2.1",
+    "@balena/autokit": "^1.2.3",
     "@balena/node-qmp": "^0.0.5",
     "@balena/node-serial-terminal": "^0.0.2",
     "@balena/testbot": "^1.9.28",


### PR DESCRIPTION
to include the new Jetson Nano based device-types.

Change-type: patch