### PR TITLE
Increase the flashing process timeout to 10m

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -443,7 +443,7 @@ async function setup(
 					if (balenaLockPath != null) {
 						await unlock(balenaLockPath);
 					}
-				}, 1000 * 60 * 5);
+				}, 1000 * 60 * 10);
 				res.status(200).send('OK');
 			} else {
 				res.status(200).send('BUSY');


### PR DESCRIPTION
On some jetson boards which use the jetson-flash node app, the worker may timeout although the flashing process has or is about to complete very soon. Let's increase this timeout to 10m, for testing purposes.

```
2025-06-15T09:04:30+00:00  worker  [  55.9766 ] 
2025-06-15T09:04:32+00:00  worker  *** The target t210ref has been flashed successfully. ***
2025-06-15T09:04:32+00:00  worker  Reset the board to boot from internal eMMC.
2025-06-15T09:04:32+00:00  worker  
2025-06-15T09:04:33+00:00  worker  INFO[2025-06-15T09:04:33.601322559Z] shim disconnected                             id=06b4106240075ac64adc30bc2552af16d7e9e5f2ba07d8142b656e939200f554
2025-06-15T09:04:33+00:00  worker  WARN[2025-06-15T09:04:33.602252812Z] cleaning up after shim disconnected           id=06b4106240075ac64adc30bc2552af16d7e9e5f2ba07d8142b656e939200f554 namespace=moby
2025-06-15T09:04:33+00:00  worker  INFO[2025-06-15T09:04:33.602285935Z] cleaning up dead shim                        
2025-06-15T09:04:33+00:00  worker  INFO[2025-06-15T09:04:33.602752535Z] ignoring event                                container=... module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
2025-06-15T09:04:33+00:00  worker  WARN[2025-06-15T09:04:33.626293789Z] cleanup warnings time="2025-06-15T09:04:33Z" level=info msg="starting signal loop" namespace=moby pid=212127 runtime=io.containerd.runc.v2 
2025-06-15T09:04:33+00:00  worker  Powering off DUT...
2025-06-15T09:08:35+00:00  worker  Did not receive heartbeat from client - Tearing down...
2025-06-15T09:08:35+00:00  worker  Performing teardown...
2025-06-15T09:08:35+00:00  worker  Tearing down Autokit...
2025-06-15T09:08:35+00:00  worker  Powering off DUT...
2025-06-15T09:08:35+00:00  worker  Toggling digital relay off
```

Change-type: patch